### PR TITLE
default env. file

### DIFF
--- a/.artifakt/app/etc/env.php.sample
+++ b/.artifakt/app/etc/env.php.sample
@@ -1,0 +1,172 @@
+<?php
+
+// dynamic conf of varnish backend 
+// based on ARTIFAKT_REPLICA_LIST env. var
+// hosts are extracted from nodes private ips and port 80 is a convention
+// see https://gitlab.com/agence-dnd-connect/artifakt-cookbooks/-/blob/e8259344b61a5858a57fd8a17fdd415f45617dbb/artifakt_docker_services/templates/default/stack/services.yaml.erb
+if (isset($_ENV['ARTIFAKT_REPLICA_LIST']) && strlen($_ENV['ARTIFAKT_REPLICA_LIST'])>0) {
+    $_host_list=explode(",", $_ENV['ARTIFAKT_REPLICA_LIST']);
+    foreach ($_host_list as $_host) {
+      $_artifakt_http_cache_hosts[]=[
+        'host'=>$_host,
+        'port'=>80
+      ];
+    }
+} else {
+  $_artifakt_http_cache_hosts=[
+    'host' => 'localhost',
+    'port' => 80
+  ];
+}
+
+return [
+    'http_cache_hosts' => $_artifakt_http_cache_hosts,
+    'cache_types' => [
+        'compiled_config' => 1,
+        'config' => 1,
+        'layout' => 1,
+        'block_html' => 1,
+        'collections' => 1,
+        'reflection' => 1,
+        'db_ddl' => 1,
+        'eav' => 1,
+        'customer_notification' => 1,
+        'config_integration' => 1,
+        'config_integration_api' => 1,
+        'full_page' => 1,
+        'config_webservice' => 1,
+        'translate' => 1
+    ],
+    'remote_storage' => [
+        'driver' => 'file'
+    ],
+    'backend' => [
+        'frontName' => (isset($_ENV['MAGENTO_BACKEND_FRONTNAME'])) ? $_ENV['MAGENTO_BACKEND_FRONTNAME'] : 'admin'
+    ],
+    'queue' => [
+        'consumers_wait_for_messages' => 0
+    ],
+    'crypt' => [
+        'key' => (isset($_ENV['MAGENTO_CRYPT_KEY'])) ? $_ENV['MAGENTO_CRYPT_KEY'] : '7bb131f36720dd1f862da4bf22372a11'
+    ],
+    'db' => [
+        'table_prefix' => '',
+        'connection' => [
+            'default' => [
+                'host' => $_ENV['ARTIFAKT_MYSQL_HOST'],
+                'dbname' => $_ENV['ARTIFAKT_MYSQL_DATABASE_NAME'],
+                'username' => $_ENV['ARTIFAKT_MYSQL_USER'],
+                'password' => $_ENV['ARTIFAKT_MYSQL_PASSWORD'],
+                'model' => 'mysql4',
+                'engine' => 'innodb',
+                'initStatements' => 'SET NAMES utf8;',
+                'active' => '1',
+                'driver_options' => [
+                    1014 => false
+                ]
+            ]
+        ]
+    ],
+    'resource' => [
+        'default_setup' => [
+            'connection' => 'default'
+        ]
+    ],
+    'x-frame-options' => 'SAMEORIGIN',
+    'MAGE_MODE' => 'production',
+    'session' => [
+        'save' => 'redis',
+        'redis' => [
+            'host' => $_ENV['ARTIFAKT_REDIS_HOST'],
+            'port' => $_ENV['ARTIFAKT_REDIS_PORT'],
+            'password' => '',
+            'timeout' => '2.5',
+            'persistent_identifier' => '',
+            'database' => '2',
+            'compression_threshold' => '2048',
+            'compression_library' => 'gzip',
+            'log_level' => '1',
+            'max_concurrency' => '60',
+            'break_after_frontend' => '5',
+            'break_after_adminhtml' => '30',
+            'first_lifetime' => '600',
+            'bot_first_lifetime' => '60',
+            'bot_lifetime' => '7200',
+            'disable_locking' => '1',
+            'min_lifetime' => '60',
+            'max_lifetime' => '2592000',
+            'sentinel_master' => '',
+            'sentinel_servers' => '',
+            'sentinel_connect_retries' => '5',
+            'sentinel_verify_master' => '0'
+        ]
+    ],
+    'cache' => [
+        'frontend' => [
+            'default' => [
+                'id_prefix' => $_ENV['ARTIFAKT_BUILD_ID'].'_',
+                'backend' => 'Magento\\Framework\\Cache\\Backend\\Redis',
+                'backend_options' => [
+                    'server' => $_ENV['ARTIFAKT_REDIS_HOST'],
+                    'database' => '0',
+                    'port' => $_ENV['ARTIFAKT_REDIS_PORT'],
+                    'password' => '',
+                    'compress_data' => '1',
+                    'compression_lib' => ''
+                ]
+            ],
+            'page_cache' => [
+                'id_prefix' => $_ENV['ARTIFAKT_BUILD_ID'].'_',
+                'backend' => 'Magento\\Framework\\Cache\\Backend\\Redis',
+                'backend_options' => [
+                    'server' => $_ENV['ARTIFAKT_REDIS_HOST'],
+                    'database' => '1',
+                    'port' => $_ENV['ARTIFAKT_REDIS_PORT'],
+                    'password' => '',
+                    'compress_data' => '0',
+                    'compression_lib' => ''
+                ]
+            ]
+        ],
+        'allow_parallel_generation' => false
+    ],
+    'lock' => [
+        'provider' => 'db',
+        'config' => [
+            'prefix' => null
+        ]
+    ],
+    'directories' => [
+        'document_root_is_pub' => true
+    ],
+    'install' => [
+        'date' => 'Thu, 24 Jun 2021 16:15:31 +0000'
+    ],
+    'system' => [
+        'default' => [
+            'catalog' => [
+                'search' => [
+                    'engine' => 'elasticsuite'
+                ]
+            ],
+            'web' => [
+                'secure' => [
+                    'base_url' => 'https://'.$_ENV['ARTIFAKT_DOMAIN'].'/'
+                ],
+                'unsecure' => [
+                    'base_url' => 'http://'.$_ENV['ARTIFAKT_DOMAIN'].'/'
+                ]
+            ],
+            'smile_elasticsuite_core_base_settings' => [
+                'es_client' => [
+                    'servers' => $_ENV['ARTIFAKT_ES_HOST'] . ':' . $_ENV['ARTIFAKT_ES_PORT'],
+                    'enable_https_mode' => ($_ENV['ARTIFAKT_ES_PORT'] == '443') ? '1' : '0',
+                    'http_auth_user' => '',
+                    'http_auth_pwd' => '',
+                    'enable_http_auth' => false
+                ]
+            ]
+        ]
+    ]    
+];
+

--- a/.artifakt/build.sh
+++ b/.artifakt/build.sh
@@ -2,6 +2,8 @@
 
 [ "$DEBUG" = "true" ] && set -x
 
+chsh -s /bin/bash www-data
+
 ROOT=/var/log/artifakt
 
 echo Init persistent folder $ROOT


### PR DESCRIPTION
This PR adds the default env file for Magento2 in FPM stack. It also enables a shell for user www-data, to support `su -c` commands during execution in pod

