### PR TITLE
enable plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,6 @@
             "magento/*": true,
             "laminas/*": true
         }
-    }        
-        
     },
     "version": "2.4.2",
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,12 @@
     "config": {
         "preferred-install": "dist",
         "sort-packages": true
+        "allow-plugins": {
+            "magento/*": true,
+            "laminas/*": true
+        }
+    }        
+        
     },
     "version": "2.4.2",
     "require": {


### PR DESCRIPTION
This PR addresses the new security feature from composer. Starting from July, plugins are disabled by default. Another fix is to use composer < 2.2 (e.g 2.1.14)
```
laminas/laminas-dependency-plugin contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe. See https://getcomposer.org/allow-plugins
You can run "composer config --no-plugins allow-plugins.laminas/laminas-dependency-plugin [true|false]" to enable it (true) or keep it disabled and suppress this warning (false)
magento/magento-composer-installer contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe. See https://getcomposer.org/allow-plugins
You can run "composer config --no-plugins allow-plugins.magento/magento-composer-installer [true|false]" to enable it (true) or keep it disabled and suppress this warning (false)
```