### PR TITLE
upgrade composer policy on plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,12 @@
     ],
     "config": {
         "preferred-install": "dist",
-        "sort-packages": true
-    },
+        "sort-packages": true,
+        "allow-plugins": {
+            "magento/*": true,
+            "laminas/*": true
+        }
+    },    
     "version": "2.4.2",
     "require": {
         "php": "~7.3.0||~7.4.0",


### PR DESCRIPTION
This PR upgrades composer.json for magento2 FPM to allow for the new default security policy in composer