### PR TITLE
install and entrypoint optims

### DIFF
--- a/.artifakt/app/etc/env.php.sample
+++ b/.artifakt/app/etc/env.php.sample
@@ -21,6 +21,10 @@ if (isset($_ENV['ARTIFAKT_REPLICA_LIST']) && strlen($_ENV['ARTIFAKT_REPLICA_LIST
   ];
 }
 
+if (!isset($_ENV['ARTIFAKT_DOMAIN'])) {
+    $_ENV['ARTIFAKT_DOMAIN']='localhost';
+}
+
 return [
     'http_cache_hosts' => $_artifakt_http_cache_hosts,
     'cache_types' => [

--- a/.artifakt/entrypoint.sh
+++ b/.artifakt/entrypoint.sh
@@ -27,6 +27,9 @@ set -e
 # ARTIFAKT_MYSQL_*
 # ARTIFAKT_ENVIRONMENT_NAME
 
+${ARTIFAKT_DOMAIN:=localhost}
+export ARTIFAKT_DOMAIN
+
 echo "#4 - Sync shared folders with Nginx FPM container"
 
 PERSISTENT_FOLDER_LIST=('pub/media' 'pub/static' 'var')

--- a/.artifakt/entrypoint.sh
+++ b/.artifakt/entrypoint.sh
@@ -59,12 +59,13 @@ wait-for $ARTIFAKT_MYSQL_HOST:3306 --timeout=90 -- echo "Mysql is up, proceeding
 # Check if Magento is installed
 tableCount=$(mysql -h $ARTIFAKT_MYSQL_HOST -u $ARTIFAKT_MYSQL_USER -p$ARTIFAKT_MYSQL_PASSWORD $ARTIFAKT_MYSQL_DATABASE_NAME -B -N -e "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = '$ARTIFAKT_MYSQL_DATABASE_NAME';" | grep -v "count");
 
-echo "DEBUG: found $tableCound tables in mysql"
+echo "DEBUG: found $tableCount tables in mysql"
 
 if [ $tableCount -eq 0 ]
 then
   if [ $ARTIFAKT_IS_MAIN_INSTANCE == 1 ]
   then
+    echo "DEBUG: triggering first install script"
     source /.artifakt/install.sh
   fi
 else

--- a/.artifakt/entrypoint.sh
+++ b/.artifakt/entrypoint.sh
@@ -138,6 +138,13 @@ else
     composer show
     echo "DEBUG --------------------------- END"    
     
+    # because base magento image is first running without ARTIFAKT_DOMAIN...
+    # ... we give the opportunity to force the ARTIFAKT_DOMAIN on second build/deploy here
+    if [ ! -z "$ARTIFAKT_DOMAIN" ]; then
+      php bin/magento config:set  --lock-env web/unsecure/base_url http://$ARTIFAKT_DOMAIN/
+      php bin/magento config:set  --lock-env web/secure/base_url https://$ARTIFAKT_DOMAIN/
+    fi
+
     #3 - Upgrade configuration if needed
     echo "#3 - Upgrade configuration if needed"
     if [ "$(bin/magento app:config:status)" != "Config files are up to date." ]

--- a/.artifakt/entrypoint.sh
+++ b/.artifakt/entrypoint.sh
@@ -56,6 +56,10 @@ cp -pu -L ./pub/* /data/pub/ || true
 echo "DEBUG: waiting for database to be available..."
 wait-for $ARTIFAKT_MYSQL_HOST:3306 --timeout=90 -- echo "Mysql is up, proceeding with starting sequence"
 
+wait-for $ARTIFAKT_REDIS_HOST:6379 --timeout=90 -- echo "Redis is up, proceeding with starting sequence"
+
+wait-for $ARTIFAKT_ES_HOST:$ARTIFAKT_ES_PORT --timeout=90 -- echo "Elasticsearch is up, proceeding with starting sequence"
+
 # Check if Magento is installed
 tableCount=$(mysql -h $ARTIFAKT_MYSQL_HOST -u $ARTIFAKT_MYSQL_USER -p$ARTIFAKT_MYSQL_PASSWORD $ARTIFAKT_MYSQL_DATABASE_NAME -B -N -e "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = '$ARTIFAKT_MYSQL_DATABASE_NAME';" | grep -v "count");
 

--- a/.artifakt/entrypoint.sh
+++ b/.artifakt/entrypoint.sh
@@ -27,7 +27,7 @@ set -e
 # ARTIFAKT_MYSQL_*
 # ARTIFAKT_ENVIRONMENT_NAME
 
-${ARTIFAKT_DOMAIN:=localhost}
+ARTIFAKT_DOMAIN=${ARTIFAKT_DOMAIN:=localhost}
 export ARTIFAKT_DOMAIN
 
 echo "#4 - Sync shared folders with Nginx FPM container"

--- a/.artifakt/entrypoint.sh
+++ b/.artifakt/entrypoint.sh
@@ -54,9 +54,9 @@ done
 cp -pu -L ./pub/* /data/pub/ || true
 
 echo "DEBUG: waiting for database to be available..."
-wait-for $ARTIFAKT_MYSQL_HOST:3306 --timeout=90 -- echo "Mysql is up, proceeding with starting sequence"
+wait-for $ARTIFAKT_MYSQL_HOST:$ARTIFAKT_MYSQL_PORT --timeout=90 -- echo "Mysql is up, proceeding with starting sequence"
 
-wait-for $ARTIFAKT_REDIS_HOST:6379 --timeout=90 -- echo "Redis is up, proceeding with starting sequence"
+wait-for $ARTIFAKT_REDIS_HOST:$ARTIFAKT_REDIS_PORT --timeout=90 -- echo "Redis is up, proceeding with starting sequence"
 
 wait-for $ARTIFAKT_ES_HOST:$ARTIFAKT_ES_PORT --timeout=90 -- echo "Elasticsearch is up, proceeding with starting sequence"
 

--- a/.artifakt/install.sh
+++ b/.artifakt/install.sh
@@ -18,7 +18,6 @@ php bin/magento setup:install \
   --admin-use-security-key="1" \
   --admin-user="admin" \
   --backend-frontname="admin" \
-  --base-url="http://localhost/" \
   --cache-backend-redis-db="0" \
   --cache-backend-redis-password='' \
   --cache-backend-redis-port="${ARTIFAKT_REDIS_PORT}" \

--- a/.artifakt/install.sh
+++ b/.artifakt/install.sh
@@ -9,7 +9,6 @@ env | grep ARTIFAKT
 # on first install, use the custom env.php file from Artifakt
 cp /.artifakt/app/etc/env.php.sample /var/www/html/app/etc/env.php
 chown www-data:www-data /var/www/html/app/etc/env.php
-php bin/magento app:config:import --no-interaction
 
 php bin/magento setup:install \
   --admin-email="email@example.com" \
@@ -61,3 +60,5 @@ if [ ! -z "$ARTIFAKT_DOMAIN" ]; then
   php bin/magento config:set  --lock-env web/unsecure/base_url http://$ARTIFAKT_DOMAIN/
   php bin/magento config:set  --lock-env web/secure/base_url https://$ARTIFAKT_DOMAIN/
 fi
+
+php bin/magento app:config:import --no-interaction

--- a/.artifakt/install.sh
+++ b/.artifakt/install.sh
@@ -6,6 +6,11 @@ echo "DEBUG: start install script, env:"
 
 env | grep ARTIFAKT
 
+# on first install, use the custom env.php file from Artifakt
+cp /.artifakt/app/etc/env.php.sample /var/www/html/app/etc/env.php
+chown www-data:www-data /var/www/html/app/etc/env.php
+php bin/magento app:config:import --no-interaction
+
 php bin/magento setup:install \
   --admin-email="email@example.com" \
   --admin-firstname="John" \
@@ -53,6 +58,6 @@ php bin/magento setup:install \
   --use-secure="0"
 
 if [ ! -z "$ARTIFAKT_DOMAIN" ]; then
-  php bin/magento config:set web/unsecure/base_url http://$ARTIFAKT_DOMAIN/
-  php bin/magento config:set web/secure/base_url https://$ARTIFAKT_DOMAIN/
+  php bin/magento config:set  --lock-env web/unsecure/base_url http://$ARTIFAKT_DOMAIN/
+  php bin/magento config:set  --lock-env web/secure/base_url https://$ARTIFAKT_DOMAIN/
 fi

--- a/.artifakt/install.sh
+++ b/.artifakt/install.sh
@@ -2,6 +2,10 @@
 
 [ "$DEBUG" = "true" ] && set -x
 
+echo "DEBUG: start install script, env:"
+
+env | grep ARTIFAKT
+
 php bin/magento setup:install \
   --admin-email="email@example.com" \
   --admin-firstname="John" \

--- a/.artifakt/install.sh
+++ b/.artifakt/install.sh
@@ -7,8 +7,8 @@ echo "DEBUG: start install script, env:"
 env | grep ARTIFAKT
 
 # on first install, use the custom env.php file from Artifakt
-cp /.artifakt/app/etc/env.php.sample /var/www/html/app/etc/env.php
-chown www-data:www-data /var/www/html/app/etc/env.php
+#cp /.artifakt/app/etc/env.php.sample /var/www/html/app/etc/env.php
+#chown www-data:www-data /var/www/html/app/etc/env.php
 
 php bin/magento setup:install \
   --admin-email="email@example.com" \


### PR DESCRIPTION
This PR patches the magento2.4 fpm entrypoint to support the following:
1. reconfigure ARTIFAKT_DOMAIN value on any deploy job
2. pass ARTIFAKT_DOMAIN to install script
3. install Artifakt custom env.php by default on a new install